### PR TITLE
XIVY-7371 Better support for selenium driver on a remote host

### DIFF
--- a/web-tester/src/main/java/com/axonivy/ivy/webtest/engine/BaseEngineUrl.java
+++ b/web-tester/src/main/java/com/axonivy/ivy/webtest/engine/BaseEngineUrl.java
@@ -1,0 +1,75 @@
+package com.axonivy.ivy.webtest.engine;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+
+import com.codeborne.selenide.Configuration;
+
+/**
+ * <p>Provide the base url of the ivy test engine.</p>
+ * <p>If selenium driver is remote then the host name of the configured ivy test engine is replaced
+ * if it is localhost, 127.0.0.1 or [::01] to the real network name of the local host.
+ * This should ensure that the selenium driver still can access the ivy test engine that is running on local host.</p>
+ * @author rwei
+ * @since Jan 5, 2022
+ */
+class BaseEngineUrl {
+
+  static final String TEST_ENGINE_URL = "test.engine.url";
+
+  static String url() {
+    return new BaseEngineUrl().evaluate();
+  }
+
+  private String evaluate() {
+    var engineUrl = System.getProperty(TEST_ENGINE_URL, "http://localhost:8081/");
+    try {
+      return evaluate(engineUrl);
+    } catch(Exception ex) {
+      return engineUrl;
+    }
+  }
+
+  private String evaluate(String engine) throws URISyntaxException, UnknownHostException {
+    var engineUri = new URI(engine);
+    if (seleniumRunsOnDifferentHost(engineUri) &&
+        isLocalHost(engineUri)) {
+      // replace localhost with real network name so that the remote selenium driver
+      // still can access the test engine
+      String hostName = InetAddress.getLocalHost().getHostName();
+      engineUri = replaceHost(engineUri, hostName);
+    }
+    return engineUri.toString();
+  }
+
+  private boolean isLocalHost(URI engineUri) {
+    String host = engineUri.getHost();
+    return "localhost".equalsIgnoreCase(host) ||
+           "127.0.0.1".equals(host) ||
+           "[::1]".equals(host);
+  }
+
+  private boolean seleniumRunsOnDifferentHost(URI engineUri) throws URISyntaxException {
+    if (Configuration.remote == null) {
+      // selenium driver does not run on remote host
+      return false;
+    }
+    URI remoteUri = new URI(Configuration.remote);
+    var remoteHost = remoteUri.getHost();
+    return remoteHost != null &&
+           !remoteHost.equalsIgnoreCase(engineUri.getHost());
+  }
+
+  private URI replaceHost(URI engineUri, String hostName) throws URISyntaxException {
+    return new URI(
+            engineUri.getScheme(),
+            engineUri.getUserInfo(),
+            hostName,
+            engineUri.getPort(),
+            engineUri.getPath(),
+            engineUri.getQuery(),
+            engineUri.getFragment());
+  }
+}

--- a/web-tester/src/main/java/com/axonivy/ivy/webtest/engine/EngineUrl.java
+++ b/web-tester/src/main/java/com/axonivy/ivy/webtest/engine/EngineUrl.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2021 Axon Ivy AG
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * This is a Util to build URLs against the designer (localhost:8081) or a test
  * engine.
- * 
+ *
  * To run a test engine have a look at the project-build-plugin:
  * https://github.com/axonivy/project-build-plugin
  */
@@ -42,7 +42,7 @@ public class EngineUrl {
 
   public static final String SLASH = "/";
   public static final String TEST_ENGINE_APP = "test.engine.app";
-  public static final String TEST_ENGINE_URL = "test.engine.url";
+  public static final String TEST_ENGINE_URL = BaseEngineUrl.TEST_ENGINE_URL;
   public static final String DESIGNER = "designer";
 
   private String base;
@@ -160,7 +160,7 @@ public class EngineUrl {
    * @return URL of engine
    */
   public static String base() {
-    return System.getProperty(TEST_ENGINE_URL, "http://localhost:8081/");
+    return BaseEngineUrl.url();
   }
 
   /**

--- a/web-tester/src/test/java/com/axonivy/ivy/webtest/engine/TestBaseEngineUrl.java
+++ b/web-tester/src/test/java/com/axonivy/ivy/webtest/engine/TestBaseEngineUrl.java
@@ -1,0 +1,104 @@
+package com.axonivy.ivy.webtest.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.codeborne.selenide.Configuration;
+
+/**
+ * Test {@link BaseEngineUrl}
+ * @author rwei
+ * @since Jan 5, 2022
+ */
+class TestBaseEngineUrl {
+
+  @AfterEach
+  void clearConfigs() {
+    Configuration.remote = null;
+    System.clearProperty(BaseEngineUrl.TEST_ENGINE_URL);
+  }
+
+  @Test
+  void defaultValue() {
+    assertThat(BaseEngineUrl.url())
+        .as("Engine url is not configured using default value")
+        .isEqualTo("http://localhost:8081/");
+  }
+
+  @Test
+  void systemProperty() {
+    System.setProperty(BaseEngineUrl.TEST_ENGINE_URL, "http://localhost:9090/ivy");
+    assertThat(BaseEngineUrl.url())
+        .as("Engine url is configured using a system property")
+        .isEqualTo("http://localhost:9090/ivy");
+  }
+
+  @Test
+  void systemProperty_noValidUri() {
+    System.setProperty(BaseEngineUrl.TEST_ENGINE_URL, "gugus sugus");
+    assertThat(BaseEngineUrl.url())
+        .as("Engine url is configured using a system property")
+        .isEqualTo("gugus sugus");
+  }
+
+
+  @Test
+  void driverRemote() throws UnknownHostException {
+    Configuration.remote = "http://selenium:5678/wd/hub";
+    assertThat(BaseEngineUrl.url())
+        .as("Selenium is running remote therefore replace localhost in engine url with explicit host name")
+        .isEqualTo("http://"+hostName()+":8081/");
+  }
+
+  @Test
+  void driverRemote_invalidUri() {
+    Configuration.remote = "hello world";
+    assertThat(BaseEngineUrl.url())
+        .as("Selenium remote config is invalid do not manipulate engine url")
+        .isEqualTo("http://localhost:8081/");
+  }
+
+  @Test
+  void driverRemote_ivyLocalIp4() throws UnknownHostException {
+    Configuration.remote = "http://selenium:5678/wd/hub";
+    System.setProperty(BaseEngineUrl.TEST_ENGINE_URL, "http://127.0.0.1:8081/");
+    assertThat(BaseEngineUrl.url())
+        .as("Selenium is running remote therefore replace localhost in engine url with explicit host name")
+        .isEqualTo("http://"+hostName()+":8081/");
+  }
+
+  @Test
+  void driverRemote_ivyLocalIp6() throws UnknownHostException {
+    Configuration.remote = "http://selenium:5678/wd/hub";
+    System.setProperty(BaseEngineUrl.TEST_ENGINE_URL, "http://[::1]:8080/ivy");
+    assertThat(BaseEngineUrl.url())
+        .as("Selenium is running remote therefore replace localhost in engine url with explicit host name")
+        .isEqualTo("http://"+hostName()+":8080/ivy");
+  }
+
+  @Test
+  void driverLocal()  {
+    Configuration.remote = "http://localhost:5678/wd/hub";
+    assertThat(BaseEngineUrl.url())
+        .as("Selenium is running local no need to replace localhost")
+        .isEqualTo("http://localhost:8081/");
+  }
+
+  @Test
+  void driverRemote_ivyRemote()  {
+    Configuration.remote = "http://localhost:5678/wd/hub";
+    System.setProperty(BaseEngineUrl.TEST_ENGINE_URL, "http://dev.axonivy.com:9090/ivy");
+    assertThat(BaseEngineUrl.url())
+        .as("Engine url is not localhost no need to change it even if driver runs remote")
+        .isEqualTo("http://dev.axonivy.com:9090/ivy");
+  }
+
+  private String hostName() throws UnknownHostException {
+    return InetAddress.getLocalHost().getHostName();
+  }
+}


### PR DESCRIPTION
If selenium driver is remote then the host name of the configured ivy
test engine is replaced if it is localhost, 127.0.0.1 or [::01] to the
real network name of the local host.

This should ensure that the selenium driver still can access the ivy
test engine that is running on local host.