### PR TITLE
XIVY-6923 Upgrade selenium-java to 4.3.0

### DIFF
--- a/primeui-tester/pom.xml
+++ b/primeui-tester/pom.xml
@@ -24,6 +24,11 @@
       <version>6.7.1</version>
     </dependency>
     <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-java</artifactId>
+      <version>4.3.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.axonivy.ivy.test</groupId>
       <artifactId>unit-tester</artifactId>
       <version>${project.version}</version>

--- a/web-tester/CHANGELOG.md
+++ b/web-tester/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Upgrade selenide to 6.7.1
+- Upgrade selenium-java to 4.3.0
 - Upgrade commons lang3 to 3.12.0
 - Upgrade junit to 5.8.1
 - Upgrade assertj-core to 3.23.1


### PR DESCRIPTION
@ivy-cst I think this is needed to have it transitive available in ivy projects at least to compile in Axon Ivy Designer.