### PR TITLE
XIVY-9395 Prevent error logs in IvyTest and IvyProcessTest

### DIFF
--- a/primeui-tester/CHANGELOG.md
+++ b/primeui-tester/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log (primeui-tester)
 
+## [9.4.1] - 2022-09-05
+
+### Bugfix
+
+- Exclude all opentelemetry dependencies in dependency hierarchy to prevent error logs in IvyTest and IvyProcessTest if this web-tester or primeui-tester is added as dependency.
+
 ## [9.4.0] - 2022-09-05
 
 ### Changed

--- a/primeui-tester/pom.xml
+++ b/primeui-tester/pom.xml
@@ -21,6 +21,14 @@
       <groupId>com.codeborne</groupId>
       <artifactId>selenide</artifactId>
       <version>6.7.4</version>
+
+      <!-- to prevent error logs when executing IvyTest and IvyProcessTest and having primeui-tester dependency in same test project -->
+      <exclusions>
+    		<exclusion>
+    			<groupId>io.opentelemetry</groupId>
+    			<artifactId>*</artifactId>
+    		</exclusion>
+    	</exclusions>
     </dependency>
     <dependency>
       <groupId>com.axonivy.ivy.test</groupId>


### PR DESCRIPTION
There are errors logs when you execute IvyProcessTest or IvyTest and you have web-tester or primeui-tester dependency. 

This is a easy fix, which should easily solve the problem. We may could configure our OpenTelemetry for testing somehow, but I don't have any idea. I think it's anyway nice to not have lesser dependencies from web-tester. 

I'll merge this already, so that I can release the web-tester once again today.
