### PR TITLE
Web Test 10.0.14

### DIFF
--- a/web-tester-fixture/pom.xml
+++ b/web-tester-fixture/pom.xml
@@ -7,7 +7,7 @@
   <version>10.0.14-SNAPSHOT</version>
   <packaging>iar-integration-test</packaging>
   <properties>
-    <project.build.plugin.version>10.0.7-SNAPSHOT</project.build.plugin.version>
+    <project.build.plugin.version>10.0.14</project.build.plugin.version>
     <engine.page.url>https://product.ivyteam.io</engine.page.url>
   </properties>
   <dependencies>


### PR DESCRIPTION
I've manually checked the project-build-plugin:10.0.14 ... seem like it was not released in the corrupt state (only the by accident released 10.0.15 is). 
So I think it's ok to use it like this.