### PR TITLE
XIVY-10310 run tests on launching Designer instance http.port

### DIFF
--- a/web-tester/src/main/java/com/axonivy/ivy/webtest/IvyTestRuntimeProps.java
+++ b/web-tester/src/main/java/com/axonivy/ivy/webtest/IvyTestRuntimeProps.java
@@ -1,0 +1,31 @@
+package com.axonivy.ivy.webtest;
+
+import java.util.Properties;
+
+class IvyTestRuntimeProps {
+
+  /** keep sync with ivy.core resource
+   *  ch.ivyteam.ivy.bpm.exec.client.restricted.IvyTestRuntime.IvyTestRuntimeIO#RESOURCE_NAME */
+  private static final String RT_PROPS = "ivyTestRuntime.properties";
+
+  public static void loadToSystem() {
+    var rtProps = loadProps();
+    rtProps.propertyNames().asIterator().forEachRemaining(it -> {
+      var key = (String)it;
+      System.setProperty(key, rtProps.getProperty(key));
+    });
+  }
+
+  public static Properties loadProps() {
+    var props = new Properties();
+    ClassLoader loader = IvyWebTestExtension.class.getClassLoader();
+    try(var in = loader.getResourceAsStream(RT_PROPS)) {
+      props.load(in);
+    } catch (Exception ex) {
+      System.err.println("Failed to read properties " + RT_PROPS);
+      ex.printStackTrace();
+    }
+    return props;
+  }
+
+}

--- a/web-tester/src/main/java/com/axonivy/ivy/webtest/IvyWebTestExtension.java
+++ b/web-tester/src/main/java/com/axonivy/ivy/webtest/IvyWebTestExtension.java
@@ -37,6 +37,7 @@ class IvyWebTestExtension implements BeforeEachCallback, BeforeAllCallback, Para
 
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
+    IvyTestRuntimeProps.loadToSystem();
     Configuration.browser = browser(context);
     Configuration.headless = headless(context);
   }


### PR DESCRIPTION
ivyTestRuntime

- with this test will always run against the correct base URI, even if multiple Designers are running

![web-it-running-on-nonDefault-port](https://github.com/user-attachments/assets/4d4fe7bb-f37b-4f5b-a723-fc15af612029)
