### PR TITLE
Prepare template to announce LTS12 changes

### DIFF
--- a/.github/release-drafter-lts12.yml
+++ b/.github/release-drafter-lts12.yml
@@ -1,0 +1,42 @@
+name-template: 'v$RESOLVED_VERSION 🔧'
+tag-template: 'v$RESOLVED_VERSION'
+filter-by-commitish: true
+commitish: release/12.0
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '📦 Dependencies'
+    label: 'dependencies'
+  - title: ⚠️ Changes
+    labels:
+      - deprecated
+  - title: 📄 Documentation
+    labels:
+      - docs
+      - documentation
+exclude-labels:
+  - 'skip-changelog'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
the templates must live on 'master' ... even though we will only consume this only from a branch.