### PR TITLE
keep jersey runtime version sync and compatible with ivy.core

### DIFF
--- a/web-tester/pom.xml
+++ b/web-tester/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>2.41</version>
+      <version>2.45</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
fixes broken testing runtime; revealed by the msgraph-connector https://github.com/axonivy-market/msgraph-connector/pull/114#discussion_r1862267331