### PR TITLE
fix build: add ssh-agent for authorized pushes using GH > R12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt update && \
-    apt install -y gnupg2 git gh
+    apt install git gnupg2 gh openssh-client -y


### PR DESCRIPTION
same fix as for build-plugin https://github.com/axonivy/project-build-plugin/commit/1230673ffce060a48d30a269372fff28ce06d8e1