### PR TITLE
Fix version update: include test.module too

### DIFF
--- a/.ivy/raise-build-plugin-version.sh
+++ b/.ivy/raise-build-plugin-version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn -f 'pom.test.xml' --batch-mode versions:set-property versions:commit -Dproperty=project.build.plugin.version -DnewVersion=${2} -DallowSnapshots=true
+mvn -f 'pom.test.xml' --batch-mode versions:set-property versions:commit -Dproperty=project.build.plugin.version -DnewVersion=${1} -DallowSnapshots=true

--- a/build/release/Jenkinsfile
+++ b/build/release/Jenkinsfile
@@ -25,8 +25,15 @@ pipeline {
             withCredentials([string(credentialsId: 'gpg.password.axonivy', variable: 'GPG_PWD'), file(credentialsId: 'gpg.keystore.axonivy', variable: 'GPG_FILE')]) {
               sh "gpg --batch --import ${env.GPG_FILE}"
               def dryRun = isReleaseBranch() ? '' : '-DdryRun=true'
-              def args = "-Dmaven.test.skip=true -Dengine.page.url=${params.engineSource} -Dskip.gpg=false -Dgpg.passphrase='${env.GPG_PWD}'";
-              maven cmd: '--batch-mode ' + dryRun + ' -Darguments="' + args + '" -DpushChanges=false -DlocalCheckout=true release:prepare release:perform'
+              def reactorArgs = "-Dmaven.test.skip=true " +
+                                "-Dengine.page.url=${params.engineSource} " +
+                                "-Dskip.gpg=false " +
+                                "-Dgpg.passphrase='${env.GPG_PWD}'"
+              def releaseArgs = "-DpomFileName=pom.test.xml " +
+                                "-DautoVersionSubmodules=true " +
+                                "-DpushChanges=false " +
+                                "-DlocalCheckout=true"
+              maven cmd: '--batch-mode -f pom.test.xml ' + dryRun + ' -Darguments="' + reactorArgs + '" ' + releaseArgs + ' release:prepare release:perform'
             }
 
             withEnv(['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']) {

--- a/pom.test.xml
+++ b/pom.test.xml
@@ -1,7 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.axonivy.ivy.webtest</groupId>
+  <parent>
+    <groupId>com.axonivy.ivy.webtest</groupId>
+    <artifactId>web-config</artifactId>
+    <version>12.0.2-SNAPSHOT</version>
+    <relativePath>maven-config</relativePath>
+  </parent>
+
   <artifactId>web-test-module</artifactId>
   <version>12.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/web-tester-fixture/pom.xml
+++ b/web-tester-fixture/pom.xml
@@ -7,7 +7,7 @@
   <version>12.0.2-SNAPSHOT</version>
   <packaging>iar-integration-test</packaging>
   <properties>
-    <project.build.plugin.version>12.0.1-SNAPSHOT</project.build.plugin.version>
+    <project.build.plugin.version>12.0.0</project.build.plugin.version>
     <engine.page.url>https://product.ivyteam.io</engine.page.url>
   </properties>
   <dependencies>


### PR DESCRIPTION
this should address the failing pipeline we saw last time, while releasing.
problem was that the versions are not sync, web-test-fixture can not found it's related 'web-tester' dependency, as it is referred by dynamic `${project.version}` re-using the artifactVersion of itself, which is not auto-updates if we don't update all proejcts in this workspace.

simulated this stuff here:
https://jenkins.ivyteam.io/job/web-tester_release/job/versions/22/console

... now it feels as if we would succesfully update all 8 pom files in this workspace:
![include-all-projects-on-release](https://github.com/user-attachments/assets/5658c9e9-34f9-4a15-add1-00e0d144e7ca)
