### PR TITLE
fix: define sem-vers tagFormat in release pom.test.xml

### DIFF
--- a/pom.test.xml
+++ b/pom.test.xml
@@ -27,6 +27,14 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <tagNameFormat>v@{project.version}</tagNameFormat>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,6 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>3.1.1</version>
-        <configuration>
-          <tagNameFormat>v@{project.version}</tagNameFormat>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
was broken in the previous release ... since we switched from 'pom.xml' to 'pom.test.xml' for releases :man_shrugging: 

![Selection_057](https://github.com/user-attachments/assets/0d131076-c07f-4b8f-9ad2-55790e339afd)
![web-tester-tagging](https://github.com/user-attachments/assets/cf80c57b-809b-40d2-9f07-71adb149ec65)
