### PR TITLE
XIVY-16780 migrate to Central Portal :camel: 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
                   def phase = isReleaseOrMasterBranch() ? 'deploy' : 'verify'
                   maven cmd: "clean ${phase} " +
                     "-f pom.test.xml " +
+                    "-P central.snapshot " +
                     "-Dmaven.test.failure.ignore=true " +
                     "-Dengine.page.url=${params.engineSource} " +
                     "-Divy.engine.version.latest.minor=true " +

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Since 9.4: Releasing is only possible on a release branch.
 
 * Create a release branch if it does not exist yet (e.g. release/10.0)
 * Run the [release build](build/release/Jenkinsfile) on the release branch
+* Confirm the publishing of the created release on the [Central Portal](https://central.sonatype.com/publishing/deployments)
 * Merge the Pull Request for next development iteration
 * If you have created a new release branch, then manually raise the version on the master branch to the next major or minor version by executing the following command in the root of this project (adjust version number accordingly):
 

--- a/build/release/Jenkinsfile
+++ b/build/release/Jenkinsfile
@@ -17,10 +17,12 @@ pipeline {
       steps {
         script {
           docker.build('maven').inside {
+            def publishingUri = "https://central.sonatype.com/publishing/deployments"
             def targetBranch = "${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
             sh "git config --global user.name 'ivy-team'"
             sh "git config --global user.email 'info@ivyteam.ch'"
             sh "git checkout -b ${targetBranch}"
+            sh "git tag -l | xargs git tag -d"
 
             withCredentials([string(credentialsId: 'gpg.password.axonivy', variable: 'GPG_PWD'), file(credentialsId: 'gpg.keystore.axonivy', variable: 'GPG_FILE')]) {
               sh "gpg --batch --import ${env.GPG_FILE}"
@@ -34,15 +36,18 @@ pipeline {
                                 "-DlocalCheckout=true"
               maven cmd: '--batch-mode -f pom.test.xml -Darguments="' + reactorArgs + '" ' + releaseArgs + ' release:prepare release:perform'
             }
+            currentBuild.description = "<a href='${publishingUri}'>publishing</a>"
 
             withEnv(['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']) {
               sshagent(credentials: ['github-axonivy']) {
                 sh "git push origin --tags"
                 sh "git push -u origin ${targetBranch}"
-                def message = "Prepare for next development cycle (${env.BRANCH_NAME})"
+
+                def title = "Prepare for next development cycle (${env.BRANCH_NAME})"
+                def message = ":warning: merge this PR only if you published the artifact on [CentralPortal](${publishingUri})"
                 withCredentials([file(credentialsId: 'github-ivyteam-token-repo-manager', variable: 'tokenFile')]) {
                   sh "gh auth login --with-token < ${tokenFile}"
-                  sh "gh pr create --title '${message}' --body '${message}' --head ${targetBranch} --base ${env.BRANCH_NAME}"
+                  sh "gh pr create --title '${title}' --body '${message}' --head ${targetBranch} --base ${env.BRANCH_NAME}"
                 }
               }
             }

--- a/build/release/Jenkinsfile
+++ b/build/release/Jenkinsfile
@@ -24,7 +24,6 @@ pipeline {
 
             withCredentials([string(credentialsId: 'gpg.password.axonivy', variable: 'GPG_PWD'), file(credentialsId: 'gpg.keystore.axonivy', variable: 'GPG_FILE')]) {
               sh "gpg --batch --import ${env.GPG_FILE}"
-              def dryRun = isReleaseBranch() ? '' : '-DdryRun=true'
               def reactorArgs = "-Dmaven.test.skip=true " +
                                 "-Dengine.page.url=${params.engineSource} " +
                                 "-Dskip.gpg=false " +
@@ -33,7 +32,7 @@ pipeline {
                                 "-DautoVersionSubmodules=true " +
                                 "-DpushChanges=false " +
                                 "-DlocalCheckout=true"
-              maven cmd: '--batch-mode -f pom.test.xml ' + dryRun + ' -Darguments="' + reactorArgs + '" ' + releaseArgs + ' release:prepare release:perform'
+              maven cmd: '--batch-mode -f pom.test.xml -Darguments="' + reactorArgs + '" ' + releaseArgs + ' release:prepare release:perform'
             }
 
             withEnv(['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']) {

--- a/maven-config/pom.xml
+++ b/maven-config/pom.xml
@@ -44,13 +44,13 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>sonatype.snapshots</id>
+      <id>central.snapshots</id>
       <name>Maven Central Snapshots Repo</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
     <repository>
-      <id>sonatype.releases</id>
-      <name>Sonatype Releases Repo</name>
+      <id>central.releases</id>
+      <name>Maven Central Releases Repo</name>
       <url>https://oss.sonatype.org/content/repositories/releases/</url>
     </repository>
   </distributionManagement>
@@ -82,17 +82,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.7.0</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>sonatype.releases</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -211,5 +200,47 @@
       </plugins>
     </pluginManagement>
   </build>
+  
+  <profiles>
+    <profile>
+      <id>central.snapshot</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central.snapshots</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>central.release</id>
+      <properties>
+        <autoRelease>false</autoRelease>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central.releases</publishingServerId>
+              <autoPublish>${autoRelease}</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/pom.test.xml
+++ b/pom.test.xml
@@ -12,6 +12,8 @@
   <version>13.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <name>web-test-module</name>
+
   <modules>
     <module>.</module>
     <module>web-tester-fixture</module>
@@ -33,6 +35,7 @@
         <version>3.1.1</version>
         <configuration>
           <tagNameFormat>v@{project.version}</tagNameFormat>
+          <releaseProfiles>central.release</releaseProfiles>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
   <version>13.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <name>web-module</name>
+
   <modules>
     <module>maven-config</module>
     <module>primeui-tester</module>

--- a/web-tester-product/pom.xml
+++ b/web-tester-product/pom.xml
@@ -12,6 +12,8 @@
   <artifactId>web-tester-product</artifactId>
   <version>13.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+  
+  <name>web-tester-product</name>
 
   <build>
     <plugins>


### PR DESCRIPTION
web-tester infra re-factoring to deploy using Central Portal :building_construction: 

- we have tested and used a similar pattern before in [ivymx](https://github.com/axonivy/ivymx/pull/134) and [project-build-plugin](https://github.com/axonivy/project-build-plugin/pull/718)

the only difference is that I've kept the 'maven-release-plugin' intact here. I think it's helpful since the situation is more complex: 
- snapshot dependencies are referred which we should not ship to the field, the release plugin prevents such deployments by default.