### PR TITLE
XIVY-16780 deployment of SNAPS with classic deploy-plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,6 @@ pipeline {
                   def phase = isReleaseOrMasterBranch() ? 'deploy' : 'verify'
                   maven cmd: "clean ${phase} " +
                     "-f pom.test.xml " +
-                    "-P central.snapshot " +
                     "-Dmaven.test.failure.ignore=true " +
                     "-Dengine.page.url=${params.engineSource} " +
                     "-Divy.engine.version.latest.minor=true " +

--- a/maven-config/pom.xml
+++ b/maven-config/pom.xml
@@ -45,7 +45,7 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>central.sonatype.snapshots</id>
+      <id>central.snapshots</id>
       <name>Maven Central Snapshots Repo</name>
       <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>

--- a/maven-config/pom.xml
+++ b/maven-config/pom.xml
@@ -128,7 +128,7 @@
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.1.4</version>
         <configuration>
-          <skip>true</skip>
+          <skip>${skip.publishing}</skip>
         </configuration>
       </plugin>
       <plugin>
@@ -203,25 +203,6 @@
   </build>
   
   <profiles>
-    <profile>
-      <id>central.snapshot</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.7.0</version>
-            <extensions>true</extensions>
-            <configuration>
-              <publishingServerId>central.snapshots</publishingServerId>
-              <autoPublish>true</autoPublish>
-              <waitUntil>published</waitUntil>
-              <skipPublishing>${skip.publishing}</skipPublishing>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>central.release</id>
       <properties>

--- a/primeui-tester/pom.xml
+++ b/primeui-tester/pom.xml
@@ -41,17 +41,4 @@
       <version>3.17.0</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/unit-tester/pom.xml
+++ b/unit-tester/pom.xml
@@ -30,17 +30,4 @@
       <version>3.27.3</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/web-tester/pom.xml
+++ b/web-tester/pom.xml
@@ -29,17 +29,4 @@
       <version>2.47</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
fix: the pipeline provides new SNAPSHOTS from master/release branches
https://central.sonatype.com/repository/maven-snapshots/com/axonivy/ivy/webtest/web-tester/13.2.0-SNAPSHOT/maven-metadata.xml