### PR TITLE
Fix waitUntil stage for deployment

### DIFF
--- a/maven-config/pom.xml
+++ b/maven-config/pom.xml
@@ -218,7 +218,7 @@
             <configuration>
               <publishingServerId>central.releases</publishingServerId>
               <autoPublish>${autoRelease}</autoPublish>
-              <waitUntil>published</waitUntil>
+              <waitUntil>uploaded</waitUntil>
               <skipPublishing>${skip.publishing}</skipPublishing>
             </configuration>
           </plugin>


### PR DESCRIPTION
I think this should fix the deployment not working.

Logs from build:
```
[WARNING] Requested to wait for state: published, but autoPublish is set to false (default). Waiting only until validated.
...
[INFO] Created bundle successfully /home/ubuntu/workspace/web-tester_release_release_12.0/target/checkout/maven-config/target/central-staging/central-bundle.zip
[INFO] Skipping Central Release Publishing at user's request.
[INFO] ------------------------------------------------------------------------
...
```