### PR TITLE
Fix central releasing > r12

### DIFF
--- a/maven-config/pom.xml
+++ b/maven-config/pom.xml
@@ -220,6 +220,10 @@
               <autoPublish>${autoRelease}</autoPublish>
               <waitUntil>uploaded</waitUntil>
               <skipPublishing>${skip.publishing}</skipPublishing>
+              <excludeArtifacts>
+                <excludeArtifact>web-tester-fixture</excludeArtifact>
+                <excludeArtifact>web-test-module</excludeArtifact>
+              </excludeArtifacts>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.test.xml
+++ b/pom.test.xml
@@ -12,10 +12,6 @@
   <version>12.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <properties>
-    <skip.publishing>true</skip.publishing>
-  </properties>
-
   <modules>
     <module>.</module>
     <module>web-tester-fixture</module>


### PR DESCRIPTION
If I understood the build properly:
- when running `mvn ... -f pom.test.xml ... release:perform` we are running the `maven-release-plugin` which has parent `maven-config` and config property `<releaseProfiles>central.release</releaseProfiles>`
- in the parent `maven-config` we have the `central.release` profile which then adds `central-publishing-maven-plugin`
- in the maven log we dont see the `defauly-deploy`  because the `central-publishing` plugin is loaded as an extensions plugin and injects its own lifecycle mapping. It binds its publish goal to the deploy phase and replaces the default deploy behavior

So i think this solution should work because we are not skipping publishing where it actually happens (`web-test-module` -> `pom.test.xml`) but we exclude the artifacts we dont wanna upload.