### PR TITLE
Exclude more artifacts

### DIFF
--- a/maven-config/pom.xml
+++ b/maven-config/pom.xml
@@ -221,6 +221,8 @@
               <waitUntil>uploaded</waitUntil>
               <skipPublishing>${skip.publishing}</skipPublishing>
               <excludeArtifacts>
+                <excludeArtifact>web-config</excludeArtifact>
+                <excludeArtifact>web-module</excludeArtifact>
                 <excludeArtifact>web-tester-fixture</excludeArtifact>
                 <excludeArtifact>web-test-module</excludeArtifact>
               </excludeArtifacts>

--- a/web-tester-product/pom.xml
+++ b/web-tester-product/pom.xml
@@ -18,6 +18,29 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <updatePomFile>true</updatePomFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>3.7.1</version>


### PR DESCRIPTION
Checked with @ivy-rew. looks like the modules do create flattened pom so the rest should not be needed
https://jenkins.ivyteam.io/job/web-tester_release/job/release%252F12.0/9/execution/node/3/ws/target/checkout/maven-config/target/central-publishing/